### PR TITLE
Apply "<fieldKey>_object" naming convention for table itemType and fieldType

### DIFF
--- a/SampleCode/LabelingUX/Client/src/store/customModel/customModel.ts
+++ b/SampleCode/LabelingUX/Client/src/store/customModel/customModel.ts
@@ -458,19 +458,20 @@ export const insertTableField = createAsyncThunk<
             const assetService = new CustomModelAssetService();
             const updatedFields = [...fields];
             const updatedDefinitions = { ...definitions };
-            const objectName = `${tableFieldKey}_object`;
+            const originTableFieldIndex = fields.findIndex((field) => field.fieldKey === tableFieldKey);
+            const originTableField: any = fields[originTableFieldIndex];
+            const objectName = originTableField.itemType || originTableField.fields[0].fieldType;
             const insertField: any = {
                 fieldKey,
                 fieldType: fieldLocation === FieldLocation.field ? objectName : FieldType.String,
                 fieldFormat: FieldFormat.NotSpecified,
             };
-            const tableFieldIndex = fields.findIndex((field) => field.fieldKey === tableFieldKey);
 
             if (fieldLocation === FieldLocation.field) {
-                const insertedFields = (fields[tableFieldIndex] as any).fields.slice();
+                const insertedFields = originTableField.fields.slice();
                 insertedFields.splice(index, 0, insertField);
-                const updatedTableField = { ...fields[tableFieldIndex], fields: insertedFields };
-                updatedFields.splice(tableFieldIndex, 1, updatedTableField);
+                const updatedTableField = { ...originTableField, fields: insertedFields };
+                updatedFields.splice(originTableFieldIndex, 1, updatedTableField);
             } else {
                 const insertedFields = definitions[objectName].fields.slice();
                 insertedFields.splice(index, 0, insertField);

--- a/SampleCode/LabelingUX/Client/src/utils/test/mockCustomModels.ts
+++ b/SampleCode/LabelingUX/Client/src/utils/test/mockCustomModels.ts
@@ -10,11 +10,6 @@ import {
 import { SharedColors } from "@fluentui/react";
 import { FeatureCategory } from "view/components/imageMap/contracts";
 
-export const mockDynamicTableFieldUUID_0 = "0b53a58a-3345-37db-e525-2c43c370bbc7";
-export const mockFixedRowTableFieldUUID_0 = "f4009382-976c-1d1d-ca9d-4db42d5d9eac";
-export const mockFixedRowTableFieldUUID_1 = "cd309d8e-1fd7-335f-e60c-3909c781556a";
-export const mockFixedColumnTableFieldUUID_0 = "b7085826-ef9a-656d-d26e-567fd5a6ccb9";
-
 export const mockFields = [
     {
         fieldKey: "Address",
@@ -35,7 +30,7 @@ export const mockFields = [
         fieldKey: "DynamicTable/abc",
         fieldType: "array",
         fieldFormat: "not-specified",
-        itemType: mockDynamicTableFieldUUID_0,
+        itemType: "DynamicTable/abc_object",
         fields: null,
     },
     {
@@ -46,12 +41,12 @@ export const mockFields = [
         fields: [
             {
                 fieldKey: "abc",
-                fieldType: mockFixedRowTableFieldUUID_0,
+                fieldType: "FixedRowTable_object",
                 fieldFormat: "not-specified",
             },
             {
                 fieldKey: "def",
-                fieldType: mockFixedRowTableFieldUUID_1,
+                fieldType: "FixedRowTable_object",
                 fieldFormat: "not-specified",
             },
         ],
@@ -65,7 +60,7 @@ export const mockFields = [
         fields: [
             {
                 fieldKey: "addr",
-                fieldType: mockFixedColumnTableFieldUUID_0,
+                fieldType: "FixedColumnTable_object",
                 fieldFormat: "not-specified",
             },
         ],
@@ -199,83 +194,10 @@ export const mockFixedColumnTableDefinition = {
     ],
 };
 
-export const mockDynamicTableDefinition_0 = {
-    fieldKey: mockDynamicTableFieldUUID_0,
-    fieldType: "object",
-    fieldFormat: "not-specified",
-    itemType: null,
-    fields: [
-        {
-            fieldKey: "CUSTOMER#",
-            fieldType: "number",
-            fieldFormat: "not-specified",
-        },
-        {
-            fieldKey: "LICNESE#",
-            fieldType: "number",
-            fieldFormat: "not-specified",
-        },
-        {
-            fieldKey: "TERMS",
-            fieldType: "string",
-            fieldFormat: "not-specified",
-        },
-    ],
-};
-export const mockFixedRowTableDefinition_0 = {
-    fieldKey: mockFixedRowTableFieldUUID_0,
-    fieldType: "object",
-    fieldFormat: "not-specified",
-    fields: [
-        {
-            fieldKey: "DATE",
-            fieldType: "date",
-            fieldFormat: "not-specified",
-        },
-        {
-            fieldKey: "INVOICE#",
-            fieldType: "number",
-            fieldFormat: "not-specified",
-        },
-    ],
-};
-
-export const mockFixedRowTableDefinition_1 = {
-    fieldKey: mockFixedRowTableFieldUUID_1,
-    fieldType: "object",
-    fieldFormat: "not-specified",
-    fields: [
-        {
-            fieldKey: "DATE",
-            fieldType: "date",
-            fieldFormat: "not-specified",
-        },
-        {
-            fieldKey: "INVOICE#",
-            fieldType: "number",
-            fieldFormat: "not-specified",
-        },
-    ],
-};
-
-export const mockFixedColumnTableDefinition_0 = {
-    fieldKey: mockFixedColumnTableFieldUUID_0,
-    fieldType: "object",
-    fieldFormat: "not-specified",
-    fields: [
-        {
-            fieldKey: "BILL TO",
-            fieldType: "string",
-            fieldFormat: "not-specified",
-        },
-    ],
-};
-
 export const mockDefinitions = {
-    [mockDynamicTableFieldUUID_0]: mockDynamicTableDefinition_0,
-    [mockFixedRowTableFieldUUID_0]: mockFixedRowTableDefinition_0,
-    [mockFixedRowTableFieldUUID_1]: mockFixedRowTableDefinition_1,
-    [mockFixedColumnTableFieldUUID_0]: mockFixedColumnTableDefinition_0,
+    [mockDynamicTableDefinition.fieldKey]: mockDynamicTableDefinition,
+    [mockFixedRowTableDefinition.fieldKey]: mockFixedRowTableDefinition,
+    [mockFixedColumnTableDefinition.fieldKey]: mockFixedColumnTableDefinition,
 } as Definitions;
 
 export const mockDynamicTableLabels = [

--- a/SampleCode/LabelingUX/Client/src/view/containers/labelPane/__snapshots__/labelPane.test.tsx.snap
+++ b/SampleCode/LabelingUX/Client/src/view/containers/labelPane/__snapshots__/labelPane.test.tsx.snap
@@ -307,7 +307,7 @@ exports[`<LabelPane /> Rendering should match snapshot, when table pane is open 
           definition={
             Object {
               "fieldFormat": "not-specified",
-              "fieldKey": "0b53a58a-3345-37db-e525-2c43c370bbc7",
+              "fieldKey": "DynamicTable/abc_object",
               "fieldType": "object",
               "fields": Array [
                 Object {
@@ -335,7 +335,7 @@ exports[`<LabelPane /> Rendering should match snapshot, when table pane is open 
               "fieldKey": "DynamicTable/abc",
               "fieldType": "array",
               "fields": null,
-              "itemType": "0b53a58a-3345-37db-e525-2c43c370bbc7",
+              "itemType": "DynamicTable/abc_object",
             }
           }
           onClickCell={[Function]}
@@ -451,7 +451,7 @@ exports[`<LabelPane /> Rendering should match snapshot, when table pane is open 
           definition={
             Object {
               "fieldFormat": "not-specified",
-              "fieldKey": "f4009382-976c-1d1d-ca9d-4db42d5d9eac",
+              "fieldKey": "FixedRowTable_object",
               "fieldType": "object",
               "fields": Array [
                 Object {
@@ -476,12 +476,12 @@ exports[`<LabelPane /> Rendering should match snapshot, when table pane is open 
                 Object {
                   "fieldFormat": "not-specified",
                   "fieldKey": "abc",
-                  "fieldType": "f4009382-976c-1d1d-ca9d-4db42d5d9eac",
+                  "fieldType": "FixedRowTable_object",
                 },
                 Object {
                   "fieldFormat": "not-specified",
                   "fieldKey": "def",
-                  "fieldType": "cd309d8e-1fd7-335f-e60c-3909c781556a",
+                  "fieldType": "FixedRowTable_object",
                 },
               ],
               "itemType": null,

--- a/SampleCode/LabelingUX/Client/src/view/containers/withCustomModelLabel/__snapshots__/withCustomModelLabel.test.tsx.snap
+++ b/SampleCode/LabelingUX/Client/src/view/containers/withCustomModelLabel/__snapshots__/withCustomModelLabel.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`withCustomModelLabel Rendering should render correctly 1`] = `
           "fieldKey": "DynamicTable/abc",
           "fieldType": "array",
           "fields": null,
-          "itemType": "0b53a58a-3345-37db-e525-2c43c370bbc7",
+          "itemType": "DynamicTable/abc_object",
         },
         Object {
           "fieldFormat": "not-specified",
@@ -65,12 +65,12 @@ exports[`withCustomModelLabel Rendering should render correctly 1`] = `
             Object {
               "fieldFormat": "not-specified",
               "fieldKey": "abc",
-              "fieldType": "f4009382-976c-1d1d-ca9d-4db42d5d9eac",
+              "fieldType": "FixedRowTable_object",
             },
             Object {
               "fieldFormat": "not-specified",
               "fieldKey": "def",
-              "fieldType": "cd309d8e-1fd7-335f-e60c-3909c781556a",
+              "fieldType": "FixedRowTable_object",
             },
           ],
           "itemType": null,
@@ -84,7 +84,7 @@ exports[`withCustomModelLabel Rendering should render correctly 1`] = `
             Object {
               "fieldFormat": "not-specified",
               "fieldKey": "addr",
-              "fieldType": "b7085826-ef9a-656d-d26e-567fd5a6ccb9",
+              "fieldType": "FixedColumnTable_object",
             },
           ],
           "itemType": null,
@@ -177,7 +177,7 @@ exports[`withCustomModelLabel Rendering should render correctly with InlineLabel
           "fieldKey": "DynamicTable/abc",
           "fieldType": "array",
           "fields": null,
-          "itemType": "0b53a58a-3345-37db-e525-2c43c370bbc7",
+          "itemType": "DynamicTable/abc_object",
         },
         Object {
           "fieldFormat": "not-specified",
@@ -187,12 +187,12 @@ exports[`withCustomModelLabel Rendering should render correctly with InlineLabel
             Object {
               "fieldFormat": "not-specified",
               "fieldKey": "abc",
-              "fieldType": "f4009382-976c-1d1d-ca9d-4db42d5d9eac",
+              "fieldType": "FixedRowTable_object",
             },
             Object {
               "fieldFormat": "not-specified",
               "fieldKey": "def",
-              "fieldType": "cd309d8e-1fd7-335f-e60c-3909c781556a",
+              "fieldType": "FixedRowTable_object",
             },
           ],
           "itemType": null,
@@ -206,7 +206,7 @@ exports[`withCustomModelLabel Rendering should render correctly with InlineLabel
             Object {
               "fieldFormat": "not-specified",
               "fieldKey": "addr",
-              "fieldType": "b7085826-ef9a-656d-d26e-567fd5a6ccb9",
+              "fieldType": "FixedColumnTable_object",
             },
           ],
           "itemType": null,


### PR DESCRIPTION
### Purpose

 Use "<fieldKey>_object" for table `itemType` and `fieldType` instead of using `uuid`

### Solution

- Instead of using `uuid`, apply `<fieldKey>_object` naming convention for table `itemType` and `fieldType`
- Refine the logic when renaming/deleting table field