### PR TITLE
Fix no label feature color on imageMap issue when first enter app

### DIFF
--- a/SampleCode/LabelingUX/Client/src/view/containers/withCustomModelLabel/withCustomModelLabel.test.tsx
+++ b/SampleCode/LabelingUX/Client/src/view/containers/withCustomModelLabel/withCustomModelLabel.test.tsx
@@ -139,6 +139,21 @@ describe("withCustomModelLabel", () => {
             expect(mockImageMap.addDrawnRegionFeatures).toBeCalledTimes(1);
         });
 
+        it("should redraw label features, when colorForFields prop change", () => {
+            const props = { ...baseProps, colorForFields: [], labels };
+            const wrapper = shallow(<WithCustomModelLabel {...props} />);
+            const instance = wrapper.instance() as any;
+            instance.setImageMap(mockImageMap);
+
+            wrapper.setProps({ colorForFields: mockColorForFields });
+            expect(mockSetLabelValueCandidates).toBeCalledTimes(1);
+            expect(mockSetLabelValueCandidates).toBeCalledWith([]);
+            expect(mockImageMap.removeAllLabelFeatures).toBeCalledTimes(1);
+            expect(mockImageMap.removeAllDrawnRegionFeature).toBeCalledTimes(1);
+            expect(mockImageMap.addLabelFeatures).toBeCalledTimes(1);
+            expect(mockImageMap.addDrawnRegionFeatures).toBeCalledTimes(1);
+        });
+
         it("should clear label features, when switch to not-labeled document.", () => {
             const notLabeledDocument = {
                 ...currentDocument,

--- a/SampleCode/LabelingUX/Client/src/view/containers/withCustomModelLabel/withCustomModelLabel.tsx
+++ b/SampleCode/LabelingUX/Client/src/view/containers/withCustomModelLabel/withCustomModelLabel.tsx
@@ -123,18 +123,14 @@ export const withCustomModelLabel = (ImageMapComponent) => {
         }
 
         public componentDidUpdate(prevProps: any) {
-            const { currentDocument, labels, hoveredLabelName } = this.props;
-            if (prevProps.currentDocument !== currentDocument && currentDocument) {
-                this.setState({ showInlineLabelMenu: false });
-                this.clearSelectedFeatures();
-                this.clearLabels();
-                this.clearRegions();
-                if (labels[currentDocument.name]?.length > 0) {
-                    this.drawLabels(currentDocument.currentPage);
-                }
-            }
+            const { currentDocument, labels, hoveredLabelName, colorForFields } = this.props;
+            const shouldRedrawLabels =
+                currentDocument &&
+                (prevProps.currentDocument !== currentDocument ||
+                    prevProps.labels !== labels ||
+                    prevProps.colorForFields !== colorForFields);
 
-            if (prevProps.labels !== labels && currentDocument) {
+            if (shouldRedrawLabels) {
                 this.setState({ showInlineLabelMenu: false });
                 this.clearSelectedFeatures();
                 this.clearLabels();


### PR DESCRIPTION
### Purpose

As shown in screenshot below, when first entering app, there's no color for label features to distinguish different labeled field

![螢幕擷取畫面 2022-12-27 120831](https://user-images.githubusercontent.com/73906265/209626436-f565a4f8-474e-477e-a89d-f000f8cbd124.png)

### Solution

- The root cause of this issue is that, the very first time label features is drawn via `WithCustomModelLabel` when entering app , the prop `colorForFields` is still empty, of which the value will be set a little bit later in `LabelList` component.

- Hence, we should check if `colorForFields` prop change in `WithCustomModelLabel` , and redraw label feature with the updated `colorForFields` prop. 