### PR TITLE
Update .gitignore and add data folder to prevent confusing error message modal

### DIFF
--- a/SampleCode/LabelingUX/.gitignore
+++ b/SampleCode/LabelingUX/.gitignore
@@ -1,7 +1,9 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # data for labeling
-/Server/data
+/Server/data/*
+
+!Server/data/.gitkeep
 
 # dependencies
 /node_modules

--- a/SampleCode/LabelingUX/.gitignore
+++ b/SampleCode/LabelingUX/.gitignore
@@ -2,7 +2,6 @@
 
 # data for labeling
 /Server/data/*
-
 !Server/data/.gitkeep
 
 # dependencies


### PR DESCRIPTION
Currently, we ask user to create data folder after they successfully run Labeling UX application. However, when user run the app for the first time without adding data folder and labeling data, the app will display an error modal as shown below, which might cause some confusion and make users think they did not set up the application correctly.

![螢幕擷取畫面 2023-01-17 145429](https://user-images.githubusercontent.com/73906265/212834352-1cda7f88-f1c0-474d-9af7-9252d76cc857.png)

If we add the `/Server/data` folder for users, users who run the application for the first time will see a more informative message modal as below. This should improve user's landing experience.

![螢幕擷取畫面 2023-01-17 151915](https://user-images.githubusercontent.com/73906265/212835260-cc7c4010-124c-442b-9670-6ce2ad7e4767.png)



