### PR TITLE
Fix: add response type with arraybuffer readBinary call

### DIFF
--- a/SampleCode/LabelingUX/Client/src/providers/storageProvider.test.ts
+++ b/SampleCode/LabelingUX/Client/src/providers/storageProvider.test.ts
@@ -45,7 +45,9 @@ describe("StorageProvider", () => {
 
     it("should handle readBinary", async () => {
         await provider.readBinary(mockFilename);
-        expect(RequestHelper.getWithAutoRetry).toBeCalledWith(`${serverUrl}/files/${mockFilename}`);
+        expect(RequestHelper.getWithAutoRetry).toBeCalledWith(`${serverUrl}/files/${mockFilename}`, {
+            responseType: "arraybuffer",
+        });
     });
 
     it("should handle writeText", async () => {

--- a/SampleCode/LabelingUX/Client/src/providers/storageProvider.ts
+++ b/SampleCode/LabelingUX/Client/src/providers/storageProvider.ts
@@ -64,7 +64,7 @@ export class StorageProvider implements IStorageProvider {
     public async readBinary(filename: string, ignoreNotFound?: boolean): Promise<Buffer | undefined> {
         try {
             const api = `${serverUrl}/files/${filename}`;
-            const result = await getWithAutoRetry(api);
+            const result = await getWithAutoRetry(api, { responseType: "arraybuffer" });
 
             return result.data;
         } catch (exception) {


### PR DESCRIPTION
To address the issue [readBinary should request an arraybuffer?](https://github.com/microsoft/Form-Recognizer-Toolkit/issues/3)
add "arraybuffer" as the responseType for the read binary function of the storage provider. 