### PR TITLE
Setting openai.api_type needed for Azure OpenAI Models

### DIFF
--- a/SampleCode/Python/sample_rag_langchain.ipynb
+++ b/SampleCode/Python/sample_rag_langchain.ipynb
@@ -120,6 +120,8 @@
    "source": [
     "# Embed the splitted documents and insert into Azure Search vector store\n",
     "\n",
+    "import openai \n",
+    "openai.api_base = os.getenv(\"AZURE_OPENAI_ENDPOINT\")\n",
     "aoai_embeddings = AzureOpenAIEmbeddings(\n",
     "    azure_deployment=\"<Azure OpenAI embeddings model>\",\n",
     "    openai_api_version=\"<Azure OpenAI API version>\",  # e.g., \"2023-07-01-preview\"\n",


### PR DESCRIPTION
For using Azure OpenAI, you need to set:
`openai.api_type = "azure"`
Otherwise, the URL is malformed or empty.
After adding these lines, it started to work for me.