### PR TITLE
Update azure-search-documents version in langchain notebook

### DIFF
--- a/SampleCode/Python/sample_rag_langchain.ipynb
+++ b/SampleCode/Python/sample_rag_langchain.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install python-dotenv langchain langchain-community langchain-openai langchainhub openai tiktoken azure-ai-documentintelligence azure-identity azure-search-documents==11.4.0b8"
+    "! pip install python-dotenv langchain langchain-community langchain-openai langchainhub openai tiktoken azure-ai-documentintelligence azure-identity azure-search-documents==11.6.0b3"
    ]
   },
   {


### PR DESCRIPTION
* Update to avoid using a version of the library that is known not to work with langchain